### PR TITLE
Run CI jobs on Ubuntu 18.04

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   test:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     strategy:
       matrix:


### PR DESCRIPTION
The libraries used by gir_ffi-gnome_keyring are no longer available in Ubuntu 20.04. Run CI with 18.04 instead.