### PR TITLE
Update coding style to match standardb

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,9 +10,18 @@ AllCops:
   NewCops: enable
   TargetRubyVersion: 2.5
 
+Layout/ArgumentAlignment:
+  EnforcedStyle: with_fixed_indentation
+
 # Make BeginEndAlignment behavior match EndAlignment
 Layout/BeginEndAlignment:
   EnforcedStyleAlignWith: begin
+
+# Allow no extra spacing just like standardrb
+Layout/ExtraSpacing:
+  AllowForAlignment: false
+  AllowBeforeTrailingComments: false
+  ForceEqualSignAlignment: false
 
 # Be lenient with line length
 Layout/LineLength:
@@ -32,9 +41,17 @@ Layout/MultilineMethodCallIndentation:
 Layout/MultilineOperationIndentation:
   EnforcedStyle: indented
 
+Layout/ParameterAlignment:
+  EnforcedStyle: with_fixed_indentation
+
 # Force consistent spacing independent of block contents
 Layout/SpaceBeforeBlockBraces:
   EnforcedStyleForEmptyBraces: space
+
+# Use standardrb style hash literals
+Layout/SpaceInsideHashLiteralBraces:
+  EnforcedStyle: no_space
+  EnforcedStyleForEmptyBraces: no_space
 
 # Assume the programmer knows how bracketed block syntax works
 Lint/AmbiguousBlockAssociation:
@@ -60,6 +77,10 @@ Performance/StartWith:
 Style/AndOr:
   EnforcedStyle: conditionals
 
+# Use standardrb style empty methods
+Style/EmptyMethod:
+  EnforcedStyle: expanded
+
 # Require at least two dependent lines before suggesting a guard clause
 Style/GuardClause:
   MinBodyLength: 2
@@ -68,18 +89,16 @@ Style/GuardClause:
 Style/Next:
   Enabled: false
 
-# Use older RuboCop default
-Style/PercentLiteralDelimiters:
-  PreferredDelimiters:
-    '%W': ()
-    '%w': ()
-
 # Allow explicit return with multiple return values
 Style/RedundantReturn:
   AllowMultipleReturnValues: true
 
 # Do not commit to use of interpolation
 Style/StringLiterals:
+  EnforcedStyle: double_quotes
+
+# Make quoting outside and inside interpolation consistent
+Style/StringLiteralsInInterpolation:
   EnforcedStyle: double_quotes
 
 # Prefer symbols to look like symbols

--- a/lib/gir_ffi-gnome_keyring.rb
+++ b/lib/gir_ffi-gnome_keyring.rb
@@ -30,15 +30,16 @@ module GnomeKeyring
     [v4, v5]
   end
 
-  def self.item_create_sync(keyring, type, display_name, attributes, secret,
-                            update_if_exists)
+  def self.item_create_sync(
+    keyring, type, display_name, attributes, secret, update_if_exists
+  )
     v1 = GirFFI::InPointer.from_utf8(keyring)
     v3 = GirFFI::InPointer.from_utf8(display_name)
     v4 = GnomeKeyring::AttributeList.from(attributes)
     v5 = GirFFI::InPointer.from_utf8(secret)
     v7 = FFI::MemoryPointer.new :uint32
-    v8 = GnomeKeyring::Lib.gnome_keyring_item_create_sync(v1, type, v3, v4, v5,
-                                                          update_if_exists, v7)
+    v8 = GnomeKeyring::Lib
+      .gnome_keyring_item_create_sync(v1, type, v3, v4, v5, update_if_exists, v7)
     v9 = v7.get_uint32(0)
     [v8, v9]
   end

--- a/lib/gir_ffi-gnome_keyring/attribute.rb
+++ b/lib/gir_ffi-gnome_keyring/attribute.rb
@@ -9,11 +9,11 @@ module GnomeKeyring
     setup_method! "list_append_uint32"
 
     private_class_method :list_new,
-                         :list_append_string,
-                         :list_append_uint32,
-                         :list_copy,
-                         :list_free,
-                         :list_to_glist
+      :list_append_string,
+      :list_append_uint32,
+      :list_copy,
+      :list_free,
+      :list_to_glist
 
     def make_finalizer
       # Don't make a finalizer; Use FFI's regular free of the pointer instead.

--- a/tasks/yardoc.rake
+++ b/tasks/yardoc.rake
@@ -4,7 +4,7 @@ begin
   require "yard"
 
   YARD::Rake::YardocTask.new do |t|
-    t.files   = ["lib/**/*.rb"]
+    t.files = ["lib/**/*.rb"]
     t.options = ["--private", "--protected", "--readme", "README.md"]
   end
 rescue LoadError

--- a/test/unit/gir_ffi-gnome_keyring_test.rb
+++ b/test/unit/gir_ffi-gnome_keyring_test.rb
@@ -37,12 +37,8 @@ describe GnomeKeyring do
         }
 
       GnomeKeyring::Lib.stub :gnome_keyring_item_create_sync, body do
-        code, id = GnomeKeyring.item_create_sync("foo",
-                                                 :generic_secret,
-                                                 "bar",
-                                                 [],
-                                                 "secret-name",
-                                                 false)
+        code, id = GnomeKeyring
+          .item_create_sync("foo", :generic_secret, "bar", [], "secret-name", false)
         _(code).must_equal :ok
         _(id).must_equal 42
       end


### PR DESCRIPTION
The code now registers no offenses with either standardb or RuboCop. In
future, more adjustments to the RuboCop configuration may be needed

- Updates RuboCop configuration for more standardrb compatibility
- Corrects new offenses
